### PR TITLE
port to new zig build API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ const libssh2 = @import("path/to/libssh2.zig");
 pub fn build(b: *std.build.Builder) void {
     // ...
 
-    const lib = libssh2.create(b, target, mode);
+    const lib = libssh2.create(b, target, optimize);
 
-    const exe = b.addExecutable("my-program", "src/main.zig");
+    const exe = b.addExecutable(.{
+        .name = "my-program",
+        .root_source_file = .{ .path = "src/main.zig" },
+    });
     lib.link(exe);
 }
 ```

--- a/build.zig
+++ b/build.zig
@@ -1,13 +1,13 @@
 const std = @import("std");
 const libssh2 = @import("libssh2.zig");
-const mbedtls = @import("mbedtls");
+const mbedtls = @import("deps.zig").build_pkgs.mbedtls;
 
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
-    const tls = mbedtls.create(b, target, mode);
-    const ssh2 = libssh2.create(b, target, mode);
+    const tls = mbedtls.create(b, target, optimize);
+    const ssh2 = libssh2.create(b, target, optimize);
     tls.link(ssh2.step);
     ssh2.step.install();
 

--- a/libssh2.zig
+++ b/libssh2.zig
@@ -47,11 +47,13 @@ pub const Library = struct {
 pub fn create(
     b: *std.build.Builder,
     target: std.zig.CrossTarget,
-    mode: std.builtin.Mode,
+    optimize: std.builtin.OptimizeMode,
 ) Library {
-    var ret = b.addStaticLibrary("ssh2", null);
-    ret.setTarget(target);
-    ret.setBuildMode(mode);
+    const ret = b.addStaticLibrary(.{
+        .name = "ssh2",
+        .target = target,
+        .optimize = optimize,
+    });
     ret.addIncludePath(include_dir);
     ret.addIncludePath(config_dir);
     ret.addCSourceFiles(srcs, &.{});


### PR DESCRIPTION
Note: I changed the way zig-mbedtls is imported in `build.zig` as the old code seems to be broken for some reason.